### PR TITLE
updated monailabel README

### DIFF
--- a/monailabel/README.md
+++ b/monailabel/README.md
@@ -111,6 +111,8 @@ Sample console output:
 
 <img src="./screenshots/console_start_3DSlicer.png" width="400">
 
+Note: For issues regarding 3D Slicer, please refer to Slicer UFRC wiki page (https://help.rc.ufl.edu/doc/Slicer).
+
 Once `3DSlicer` opens up, switch back to the console tab. We'll come back after setting up the MONAI Label server.
 <img src="./screenshots/switch_to_console.png" width="400">
 


### PR DESCRIPTION
added a potentially helpful line linking to 3D Slicer UFRC wiki page; took me a few hours to get Slicer running on an OOD desktop, only to find out I had extra step of 'export MESA_GL_VERSION_OVERRIDE=3.2' to resolve several OpenGL errors;